### PR TITLE
Save start and fixed as part of call

### DIFF
--- a/R/mle.R
+++ b/R/mle.R
@@ -237,11 +237,13 @@ mle2 <- function(minuslogl,
         }
     ## also check parnames(minuslogl)?
     if (missing(start) && default.start) start <- formals(minuslogl)
+    call$start <- eval.parent(call$start)
     if (!is.null(fixed) && !is.list(fixed)) {
         if (is.null(names(fixed)) || !is.vector(fixed))
             stop("'fixed' must be a named vector or named list")
         fixed <- as.list(fixed)
     }
+    call$fixed <- eval.parent(call$fixed)
     if (!is.null(data) && !is.list(data)) ##  && !is.environment(data)) 
         stop("'data' must be a list")
     nfix <- names(unlist(namedrop(fixed)))


### PR DESCRIPTION
Currently, neither the start nor fixed variables are maintained as part of a fit. This can lead to problems later on since they may be variables that are not part of the environment to which the fit is returned. For example, fixed is needed in order to run profile/proffun and confint.

Following the process by which other variables (e.g., call$data, call$upper, call$lower, etc) are stored, it seems reasonable that start be maintained in full as call$start and that fixed be maintained in full as call$fixed.